### PR TITLE
feat: add login endpoint and setup backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # thinkr
+
+### Backend
+
+1. `npm install`.
+2. Set up mongoDB (connection URI)
+3. Set up google auth credentials (client id) in Google Cloud Console.
+4. Generate JWT secret, you can use this https://jwtsecret.com/generate.
+5. Create a `.env` file in root of `backend` directory with:
+```
+GOOGLE_CLIENT_ID=<web_client_ID_from_google_cloud_credentials>
+JWT_SECRET=<randomly_generated_jwt_secret>
+MONGO_URI=<your_mongoDB_connection_URI>
+```
+6. `npm start` or `npm run dev` (nodemon).

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 dist
+.env

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 4,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,0 +1,6 @@
+{
+    "watch": ["src"],
+    "ext": "ts",
+    "ignore": ["src/**/*.test.ts"],
+    "exec": "ts-node ./src/index.ts"
+  }

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,18 +5,27 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "dev": "tsc && node dist/index.js"
+    "start": "tsc && node dist/index.js",
+    "lint": "prettier --check ./src",
+    "lint-apply": "prettier --write ./src",
+    "dev": "nodemon ./src/index.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.21.2"
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "google-auth-library": "^9.15.1",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.10.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.8",
     "@types/node": "^22.13.1",
+    "nodemon": "^3.1.9",
+    "prettier": "^3.5.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   }

--- a/backend/src/controllers/userAuthController.ts
+++ b/backend/src/controllers/userAuthController.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from 'express';
+import UserService from '../services/userAuthService';
+import { Result, UserDTO } from '../interfaces';
+
+/**
+ * Handles user login with google auth and jwt
+ */
+export const userAuthLogin = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        res.status(400).json({
+            message: 'Authorization header is missing or invalid',
+        } as Result);
+        return;
+    }
+
+    const idToken = authHeader.split(' ')[1];
+    const googleUser = await UserService.verifyGoogleToken(idToken);
+
+    if (!googleUser) {
+        res.status(401).json({
+            message: 'Invalid Google token',
+        } as Result);
+        return;
+    }
+
+    const user: UserDTO = await UserService.findCreateUser(googleUser);
+    const token = UserService.generateToken(user.id);
+
+    res.status(200).json({
+        data: { token, user },
+    } as Result);
+};

--- a/backend/src/db/mongo/connection.ts
+++ b/backend/src/db/mongo/connection.ts
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const MONGO_URI = process.env.MONGO_URI!;
+
+const connectMongoDB = async () => {
+    try {
+        await mongoose.connect(MONGO_URI);
+        console.log('MongoDB connected successfully');
+    } catch (error) {
+        console.error('MongoDB connection error:', error);
+        process.exit(1);
+    }
+};
+
+export default connectMongoDB;

--- a/backend/src/db/mongo/models/User.ts
+++ b/backend/src/db/mongo/models/User.ts
@@ -1,0 +1,20 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Interface representing a user in database for data transfer between backend <-> DB
+ */
+export interface IUser extends Document {
+    email: string;
+    name?: string;
+    googleId: string;
+}
+
+const userSchema = new Schema<IUser>({
+    email: { type: String, required: true, unique: true },
+    name: { type: String },
+    googleId: { type: String, required: true, unique: true },
+});
+
+const User = model<IUser>('User', userSchema);
+
+export default User;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,1 +1,18 @@
-console.log("hello world")
+import express from 'express';
+import dotenv from 'dotenv';
+import authRouter from './routes/userAuthRoutes';
+import connectMongoDB from './db/mongo/connection';
+
+dotenv.config();
+
+const PORT = 3000;
+const app = express();
+
+app.use(express.json());
+app.use('/auth', authRouter);
+// TODO: Protect routes?
+
+connectMongoDB();
+app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}`);
+});

--- a/backend/src/interfaces/index.ts
+++ b/backend/src/interfaces/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Represents API result
+ */
+export interface Result {
+    message?: string;
+    data?: any;
+}
+
+/**
+ * Represents a user for data transfer between frontend <-> backend
+ */
+export interface UserDTO {
+    email: string;
+    name?: string;
+    googleId?: string;
+    id: string;
+}

--- a/backend/src/routes/userAuthRoutes.ts
+++ b/backend/src/routes/userAuthRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { userAuthLogin } from '../controllers/userAuthController';
+
+const router = Router();
+
+router.post('/login', userAuthLogin);
+
+export default router;

--- a/backend/src/services/userAuthService.ts
+++ b/backend/src/services/userAuthService.ts
@@ -1,0 +1,82 @@
+import { OAuth2Client, TokenPayload } from 'google-auth-library';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import User from '../db/mongo/models/User';
+import { UserDTO } from '../interfaces';
+
+dotenv.config();
+
+class UserAuthService {
+    private googleClient: OAuth2Client;
+    private jwtSecret: string;
+
+    constructor() {
+        this.googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+        this.jwtSecret = process.env.JWT_SECRET!;
+    }
+
+    /**
+     * Verifies a Google ID token and returns the payload.
+     */
+    public async verifyGoogleToken(
+        idToken: string
+    ): Promise<TokenPayload | null> {
+        try {
+            const ticket = await this.googleClient.verifyIdToken({
+                idToken,
+                audience: process.env.GOOGLE_CLIENT_ID,
+            });
+            const payload = ticket.getPayload();
+            return payload || null;
+        } catch (error) {
+            console.error('Error verifying Google token: ', error);
+            return null;
+        }
+    }
+
+    /**
+     * Generates a JWT for a user.
+     */
+    public generateToken(userId: string): string {
+        return jwt.sign({ userId }, this.jwtSecret, { expiresIn: '1h' });
+    }
+
+    /**
+     * Verifies a JWT and returns the decoded payload.
+     */
+    public verifyToken(token: string): { userId: string } | null {
+        try {
+            const decoded = jwt.verify(token, this.jwtSecret) as {
+                userId: string;
+            };
+            return decoded;
+        } catch (error) {
+            console.error('Error verifying JWT: ', error);
+            return null;
+        }
+    }
+
+    /**
+     * Finds user and creates user if user is not found based on Google credentials.
+     */
+    public async findCreateUser(googleUser: TokenPayload): Promise<UserDTO> {
+        let user = await User.findOne({ googleId: googleUser.sub });
+        if (!user) {
+            user = new User({
+                name: googleUser.name,
+                email: googleUser.email,
+                googleId: googleUser.sub,
+            });
+            await user.save();
+        }
+
+        return {
+            email: googleUser.email!,
+            name: googleUser.name,
+            googleId: googleUser.sub,
+            id: user._id,
+        } as UserDTO;
+    }
+}
+
+export default new UserAuthService();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,111 +1,19 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Setup backend + mongodb
- Added login endpoint: 
    -`POST /auth/login`
    - **Request:**
        - No request body
        - Requires Authorization header with a JWT Bearer token
    - **Response:**
        - Returns user information: `name`, `email`, `googleID` and a JWT access token.
        ```typescript
        {
            "data": {
                "token":  <string> // jwt access token,
                "user": { 
                    "email": <string>,
                    "name": <string>,
                    "googleId": <string>,
                    "id": <string> // id for user document from mongodb
                }
            }
        }
        ```
**REQUIRED ENV VARS** in `backend/.env`:
```
GOOGLE_CLIENT_ID=<web_client_ID_from_google_cloud_credentials>
JWT_SECRET=<randomly_generated_jwt_secret>
MONGO_URI=<your_mongoDB_connection_URI>
```
I tested this with `https://developers.google.com/oauthplayground/` which requires your google web client ID to authorize the redirect URL `https://developers.google.com/oauthplayground`. I didn't set this up to work with mobile for now, since we don't have central configurations to use so I'm using my own for now.

In our docs, we say login and signup cover two different functionalities, but I think login and signup is kind of the same functionality especially if we are only using google for auth. I will change the docs for the `UserService` interface if this is good. 