### PR TITLE
feat: add document upload endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
    MONGO_URI=<your_mongodb_uri>
    OPENAI_API_KEY=<your_openai_api_key>
    VECTOR_STORE_URL=http://localhost:8000
+   AWS_ACCESS_KEY_ID=<your AWS access key>
+   AWS_SECRET_ACCESS_KEY=<your AWS IAM secret access key>
+   AWS_REGION=<your aws_region>
+   S3_BUCKET_NAME=<your s3 bucket name>
    ```
 6. **Run ChromaDB:**
    Ensure Docker is running, then execute:
@@ -33,9 +37,102 @@
   - Endpoint: `/auth/login`
   - Method: `POST`
   - Headers: `Authorization: Bearer <Google ID Token>`
-
+  - Body: N/A
+  - Response:
+  ```json
+  {
+      "data": {
+         "token":  <string> // jwt access token,
+         "user": { 
+               "email": <string>,
+               "name": <string>,
+               "googleId": <string>,
+               "id": <string> // db user id
+         }
+      }
+   }
+   ```
 - **RAG Query:**
   - Endpoint: `/rag/query`
   - Method: `POST`
-  - Body: `{ "query": "Your question here" }`
+  - Body: raw 
+   ```json
+   { 
+      "query": "Your question here" 
+   }
+   ```
 
+- **Documents:**
+  - Endpoint: `/document/upload`
+  - Method: `POST`
+  - Body: multipart/form-data
+   ```json
+   {
+      "documents": "<your file(s) here>",
+      "email": "user email"
+   }
+   ```
+  - Response:
+  ```json
+   {
+      "data": {
+         "docs": [
+            {
+               "name": "first file",
+               "uploadTime": "time of file upload"
+            },
+            {
+               "name": "second file",
+               "uploadTime": "time of file upload"
+            }
+         ]
+      }
+   }
+  ```
+
+  - Endpoint: `/document/delete`
+  - Method: `DELETE`
+  - Body: raw
+   ```json
+   {
+      "email": "your email",
+      "paths": [
+         "name of first file you want to delete",
+         "name of second file you want to delete"
+      ]
+   }
+   ```
+  - Response: N/A
+
+  - Endpoint: `/document/retrieve`
+  - Method: `GET`
+  - Body: raw
+  ```json
+   {
+      "email": "rayhownh@gmail.com",
+      "paths": [
+         "name of first file you want",
+         "name of second file you want"
+      ] // optional
+   }
+  ```
+  - Response:
+  ```json
+   {
+      "data": {
+         "docs": [
+            {
+               "url": "second file's s3 document urlt",
+               "name": "first file",
+               "uploadTime": "time of file upload"
+            },
+            {
+               "url": "second file's s3 document url",
+               "name": "second file",
+               "uploadTime": "time of file upload"
+            }
+         ]
+      }
+   }
+  ```
+  - Note: Returns all of the user's files if no paths are provided

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,16 +15,21 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.750.0",
+    "@aws-sdk/client-textract": "^3.750.0",
+    "@aws-sdk/s3-request-presigner": "^3.750.0",
     "@langchain/community": "^0.3.32",
     "@langchain/core": "^0.3.40",
     "@langchain/openai": "^0.4.4",
+    "@types/multer": "^1.4.12",
     "chromadb": "^1.10.4",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "google-auth-library": "^9.15.1",
     "jsonwebtoken": "^9.0.2",
     "langchain": "^0.3.19",
-    "mongoose": "^8.10.1"
+    "mongoose": "^8.10.1",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/backend/src/controllers/documentController.ts
+++ b/backend/src/controllers/documentController.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from 'express';
+import DocumentService from '../services/documentService';
+import { Result } from '../interfaces';
+
+/**
+ * Handles document uploads
+ *
+ */
+export const uploadDocuments = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    const { email } = req.body;
+
+    if (!req.files || !Array.isArray(req.files)) {
+        res.status(400).json({
+            message: 'No files uploaded',
+        } as Result);
+        return;
+    }
+
+    try {
+        const files = req.files as Express.Multer.File[];
+        const docs = await DocumentService.uploadDocuments(files, email);
+
+        res.status(200).json({
+            data: { docs },
+        } as Result);
+    } catch (error) {
+        console.error('Error uploading documents:', error);
+
+        res.status(500).json({
+            message: 'Failed to upload documents',
+        } as Result);
+    }
+};
+
+/**
+ * Handles deleting documents
+ *
+ */
+export const deleteDocuments = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    const { email, paths } = req.body;
+
+    if (!email || !paths || !Array.isArray(paths)) {
+        res.status(400).json({
+            message: 'Email and paths are required',
+        } as Result);
+        return;
+    }
+
+    try {
+        await DocumentService.deleteDocuments(paths, email);
+        res.status(200).json();
+        return;
+    } catch (error) {
+        console.error('Error deleting documents:', error);
+
+        res.status(500).json({
+            message: 'Failed to delete documents',
+        } as Result);
+    }
+};
+
+/**
+ * Handles retrieving documents
+ *
+ */
+export const getDocuments = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    const { paths, email } = req.body;
+
+    if (!email || (paths && !Array.isArray(paths))) {
+        res.status(400).json({
+            message: 'Email and paths are required',
+        } as Result);
+        return;
+    }
+
+    try {
+        const docs = await DocumentService.getDocuments(paths, email);
+
+        const result: Result = {
+            data: { docs },
+        };
+        res.status(200).json(result);
+    } catch (error) {
+        console.error('Error retrieving document URL:', error);
+        const result: Result = {
+            message: 'Failed to retrieve document URL',
+        };
+        res.status(500).json(result);
+    }
+};

--- a/backend/src/db/mongo/models/Document.ts
+++ b/backend/src/db/mongo/models/Document.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document as MongooseDocument } from 'mongoose';
+
+export interface IDocument extends MongooseDocument {
+    name: string;
+    email: string;
+    uploadDate: string;
+    s3Path: string;
+    embeddingsId: string;
+}
+
+const documentSchema = new Schema<IDocument>({
+    name: { type: String, required: true },
+    email: { type: String, required: true },
+    uploadDate: { type: String, required: true },
+    s3Path: { type: String, required: true, unique: true },
+    embeddingsId: { type: String, required: true },
+});
+
+const Document = model<IDocument>('Document', documentSchema);
+
+export default Document;

--- a/backend/src/db/mongo/models/User.ts
+++ b/backend/src/db/mongo/models/User.ts
@@ -1,8 +1,5 @@
 import { Schema, model, Document } from 'mongoose';
 
-/**
- * Interface representing a user in database for data transfer between backend <-> DB
- */
 export interface IUser extends Document {
     email: string;
     name?: string;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import authRouter from './routes/userAuthRoutes';
 import connectMongoDB from './db/mongo/connection';
 import RAGService from './services/RAGService';
+import documentRouter from './routes/documentRoutes';
 
 dotenv.config();
 
@@ -11,6 +12,7 @@ const app = express();
 
 app.use(express.json());
 app.use('/auth', authRouter);
+app.use('/document', documentRouter);
 
 // RAG endpoint
 app.post('/rag/query', (req: Request, res: Response): Promise<void> => {
@@ -24,10 +26,13 @@ app.post('/rag/query', (req: Request, res: Response): Promise<void> => {
 
             const ragService = new RAGService({
                 openAIApiKey: process.env.OPENAI_API_KEY!,
-                vectorStoreUrl: process.env.VECTOR_STORE_URL!
+                vectorStoreUrl: process.env.VECTOR_STORE_URL!,
             });
 
-            const documents = await ragService.fetchRelevantDocuments(query);
+            const documents = await ragService.fetchRelevantDocuments(
+                query,
+                'documents'
+            );
             const response = await ragService.queryLLM(query, documents);
 
             res.json({ response });
@@ -37,7 +42,6 @@ app.post('/rag/query', (req: Request, res: Response): Promise<void> => {
         }
     })();
 });
-
 
 connectMongoDB();
 

--- a/backend/src/interfaces/index.ts
+++ b/backend/src/interfaces/index.ts
@@ -15,3 +15,13 @@ export interface UserDTO {
     googleId?: string;
     id: string;
 }
+
+/**
+ * Represents a document for data transfer between frontend <-> backend
+ */
+export interface DocumentDTO {
+    url?: string;
+    name: string;
+    uploadTime: string;
+}
+

--- a/backend/src/routes/documentRoutes.ts
+++ b/backend/src/routes/documentRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+    deleteDocuments,
+    getDocuments,
+    uploadDocuments,
+} from '../controllers/documentController';
+import multer from 'multer';
+
+const upload = multer();
+const router = Router();
+
+router.post('/upload', upload.array('documents'), uploadDocuments);
+router.delete('/delete', deleteDocuments);
+router.get('/retrieve', getDocuments);
+
+export default router;

--- a/backend/src/scripts/initChroma.ts
+++ b/backend/src/scripts/initChroma.ts
@@ -7,37 +7,32 @@ dotenv.config();
 
 async function initializeChroma() {
     const client = new ChromaClient({ path: process.env.VECTOR_STORE_URL });
-    
+
     // Create embeddings instance
     const embeddings = new OpenAIEmbeddings({
-        openAIApiKey: process.env.OPENAI_API_KEY
+        openAIApiKey: process.env.OPENAI_API_KEY,
     });
 
     // Create or get collection
     const collection = await client.createCollection({
-        name: "documents",
-        metadata: { "description": "Test documents collection" }
+        name: 'documents',
+        metadata: { description: 'Test documents collection' },
     });
 
     // Example documents
     const documents = [
-        "This is a test document about artificial intelligence.",
+        'This is a test document about artificial intelligence.',
         "Here's another document about machine learning.",
-        "This document discusses natural language processing."
+        'This document discusses natural language processing.',
     ];
 
     // Create Chroma instance with documents
-    await Chroma.fromTexts(
-        documents,
-        { source: "test" },
-        embeddings,
-        {
-            collectionName: "documents",
-            url: process.env.VECTOR_STORE_URL
-        }
-    );
+    await Chroma.fromTexts(documents, { source: 'test' }, embeddings, {
+        collectionName: 'documents',
+        url: process.env.VECTOR_STORE_URL,
+    });
 
-    console.log("ChromaDB initialized with test documents!");
+    console.log('ChromaDB initialized with test documents!');
 }
 
-initializeChroma().catch(console.error); 
+initializeChroma().catch(console.error);

--- a/backend/src/services/RAGService.ts
+++ b/backend/src/services/RAGService.ts
@@ -3,6 +3,7 @@ import { Document } from '@langchain/core/documents';
 import { ChatOpenAI } from '@langchain/openai';
 import { Chroma } from '@langchain/community/vectorstores/chroma';
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import { ChromaClient } from 'chromadb';
 
 /**
  * Represents configuration options for RAGService
@@ -41,42 +42,44 @@ class RAGService {
     private llm: ChatOpenAI;
     private vectorStore: Chroma | null = null;
     private maxContextLength: number;
+    private vectorStoreUrl: string;
 
     constructor(config: RAGServiceConfig) {
         this.embeddings = new OpenAIEmbeddings({
-            openAIApiKey: config.openAIApiKey
+            openAIApiKey: config.openAIApiKey,
         });
 
         this.llm = new ChatOpenAI({
             openAIApiKey: config.openAIApiKey,
-            temperature: config.temperature || 0.7
+            temperature: config.temperature || 0.7,
         });
 
         this.maxContextLength = config.maxContextLength || 4000;
+        this.vectorStoreUrl = config.vectorStoreUrl;
     }
 
     /**
      * Initialize connection to vector store
      */
-    private async initVectorStore(vectorStoreUrl: string): Promise<void> {
+    private async initVectorStore(collectionName: string): Promise<void> {
         try {
             this.vectorStore = await Chroma.fromExistingCollection(
                 this.embeddings,
-                { 
-                    collectionName: "documents",
-                    url: vectorStoreUrl
+                {
+                    collectionName: collectionName,
+                    url: this.vectorStoreUrl,
                 }
             );
         } catch (error: unknown) {
             console.error('Vector store initialization error:', error);
             // Create a new collection if it doesn't exist
             this.vectorStore = await Chroma.fromTexts(
-                ["Initial document"],
-                { source: "initialization" },
+                ['Initial document'],
+                { source: 'initialization' },
                 this.embeddings,
                 {
-                    collectionName: "documents",
-                    url: vectorStoreUrl
+                    collectionName: collectionName,
+                    url: this.vectorStoreUrl,
                 }
             );
         }
@@ -85,22 +88,73 @@ class RAGService {
     /**
      * Ensure vector store is initialized before use
      */
-    private async ensureVectorStore(vectorStoreUrl: string): Promise<void> {
+    public async ensureVectorStore(collectionName: string): Promise<void> {
         if (!this.vectorStore) {
-            await this.initVectorStore(vectorStoreUrl);
+            await this.initVectorStore(collectionName);
+        }
+    }
+
+    /**
+     * Insert a document into a vector db collection
+     */
+    public async insertDocument(
+        collectionName: string,
+        text: string,
+        key: string
+    ): Promise<string> {
+        try {
+            const docs = [
+                { pageContent: text, metadata: { source: collectionName } },
+            ];
+            const id = {
+                ids: [key],
+            };
+            await this.vectorStore!.addDocuments(docs, id);
+
+            console.log(
+                `Text uploaded to Chroma DB in collection ${collectionName}: ${key}`
+            );
+            return key;
+        } catch (error) {
+            console.error('Error uploading text to Chroma DB:', error);
+            throw new Error('Failed to upload text to Chroma DB');
+        }
+    }
+
+    /**
+     * Deletes documents in a vector DB collection
+     */
+    public async deleteDocuments(
+        ids: string[],
+        collectionName: string
+    ): Promise<void> {
+        try {
+            await this.ensureVectorStore(collectionName);
+            await this.vectorStore!.collection!.delete({ ids });
+
+            console.log(
+                `Deleted embeddings in Chroma DB collection ${collectionName}: ${ids}`
+            );
+            return;
+        } catch (error) {
+            console.error('Error deleting embeddings to Chroma DB:', error);
+            throw new Error('Failed to delete embeddings in Chroma DB');
         }
     }
 
     /**
      * Fetch relevant documents based on query similarity
      */
-    public async fetchRelevantDocuments(query: string): Promise<Document<DocumentMetadata>[]> {
+    public async fetchRelevantDocuments(
+        query: string,
+        collectionName: string
+    ): Promise<Document<DocumentMetadata>[]> {
         try {
             if (!query.trim()) {
                 throw new RAGServiceError('Query cannot be empty');
             }
 
-            await this.ensureVectorStore(process.env.VECTOR_STORE_URL!);
+            await this.ensureVectorStore(collectionName);
 
             if (!this.vectorStore) {
                 throw new RAGServiceError('Vector store not initialized');
@@ -108,19 +162,25 @@ class RAGService {
 
             const documents = await this.vectorStore.similaritySearch(query, 5);
             return documents;
-
         } catch (error: unknown) {
             if (error instanceof Error) {
-                throw new RAGServiceError(`Error fetching relevant documents: ${error.message}`);
+                throw new RAGServiceError(
+                    `Error fetching relevant documents: ${error.message}`
+                );
             }
-            throw new RAGServiceError('Error fetching relevant documents: Unknown error');
+            throw new RAGServiceError(
+                'Error fetching relevant documents: Unknown error'
+            );
         }
     }
 
     /**
      * Query LLM with context-aware prompting
      */
-    public async queryLLM(query: string, contextDocuments: Document<DocumentMetadata>[]): Promise<string> {
+    public async queryLLM(
+        query: string,
+        contextDocuments: Document<DocumentMetadata>[]
+    ): Promise<string> {
         try {
             // Validate inputs
             if (!query.trim()) {
@@ -132,18 +192,21 @@ class RAGService {
 
             // Create messages for the chat model
             const messages = [
-                new SystemMessage("You are a helpful assistant that answers questions based on the provided context."),
-                new HumanMessage(`Context: ${context}\n\nQuestion: ${query}`)
+                new SystemMessage(
+                    'You are a helpful assistant that answers questions based on the provided context.'
+                ),
+                new HumanMessage(`Context: ${context}\n\nQuestion: ${query}`),
             ];
 
             // Generate response
             const response = await this.llm.call(messages);
 
             return response.content as string;
-
         } catch (error: unknown) {
             if (error instanceof Error) {
-                throw new RAGServiceError(`Error querying LLM: ${error.message}`);
+                throw new RAGServiceError(
+                    `Error querying LLM: ${error.message}`
+                );
             }
             throw new RAGServiceError('Error querying LLM: Unknown error');
         }
@@ -154,15 +217,15 @@ class RAGService {
      */
     private constructContext(documents: Document<DocumentMetadata>[]): string {
         let context = '';
-        
+
         for (const doc of documents) {
             // Simple token estimation (can be replaced with more accurate counting)
             const estimatedTokens = doc.pageContent.length / 4;
-            
-            if ((context.length / 4) + estimatedTokens > this.maxContextLength) {
+
+            if (context.length / 4 + estimatedTokens > this.maxContextLength) {
                 break;
             }
-            
+
             context += `${doc.pageContent}\n\n`;
         }
 
@@ -186,4 +249,4 @@ Answer:`;
     }
 }
 
-export default RAGService; 
+export default RAGService;

--- a/backend/src/services/documentParserService.ts
+++ b/backend/src/services/documentParserService.ts
@@ -1,0 +1,63 @@
+import {
+    TextractClient,
+    AnalyzeDocumentCommand,
+    FeatureType,
+} from '@aws-sdk/client-textract';
+import dotenv from 'dotenv';
+dotenv.config();
+
+class DocumentParser {
+    private textractClient: TextractClient;
+    private bucketName: string;
+
+    constructor() {
+        this.bucketName = process.env.S3_BUCKET_NAME!;
+        this.textractClient = new TextractClient({
+            region: process.env.AWS_REGION,
+            credentials: {
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+            },
+        });
+    }
+
+    /**
+     * Extracts text from a file using AWS Textract.
+     */
+    public async extractTextFromFile(s3FilePath: string): Promise<string> {
+        const params = {
+            Document: {
+                S3Object: {
+                    Bucket: this.bucketName,
+                    Name: s3FilePath,
+                },
+            },
+            FeatureTypes: [
+                FeatureType.TABLES,
+                FeatureType.FORMS,
+                FeatureType.SIGNATURES,
+            ],
+        };
+
+        try {
+            const command = new AnalyzeDocumentCommand(params);
+            const response = await this.textractClient.send(command);
+
+            let extractedText = '';
+            if (response.Blocks) {
+                for (const block of response.Blocks) {
+                    if (block.BlockType === 'LINE' && block.Text) {
+                        extractedText += block.Text + '\n';
+                    }
+                }
+            }
+
+            return extractedText.trim();
+        } catch (error) {
+            console.error('Error extracting text from PDF:', error);
+            throw new Error('Failed to extract text from PDF');
+        }
+    }
+}
+
+export default new DocumentParser();

--- a/backend/src/services/documentService.ts
+++ b/backend/src/services/documentService.ts
@@ -1,0 +1,195 @@
+import {
+    S3Client,
+    PutObjectCommand,
+    DeleteObjectCommand,
+    GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import dotenv from 'dotenv';
+import Document from '../db/mongo/models/Document';
+import DocumentParser from './documentParserService';
+import RAGService from './RAGService';
+import { DocumentDTO } from '../interfaces';
+
+dotenv.config();
+
+class DocumentService {
+    private s3Client: S3Client;
+    private bucketName: string;
+    private date: Date;
+    private ragService: RAGService;
+
+    constructor() {
+        this.s3Client = new S3Client({
+            region: process.env.region,
+            credentials: {
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+            },
+        });
+        this.bucketName = process.env.S3_BUCKET_NAME!;
+        this.date = new Date();
+        this.ragService = new RAGService({
+            openAIApiKey: process.env.OPENAI_API_KEY!,
+            vectorStoreUrl: process.env.VECTOR_STORE_URL!,
+        });
+    }
+
+    /**
+     * Uploads a file to s3 and mongodb
+     *
+     */
+    public async uploadDocument(
+        file: Express.Multer.File,
+        email: string,
+        user: string
+    ): Promise<DocumentDTO> {
+        const key = `${email}-${file.originalname}`;
+
+        const params = {
+            Bucket: this.bucketName,
+            Key: key,
+            Body: file.buffer,
+            ContentType: file.mimetype,
+        };
+
+        // s3
+        const command = new PutObjectCommand(params);
+        await this.s3Client.send(command);
+        const dateFormatted = this.date
+            .toISOString()
+            .replace(/T/, ' ')
+            .replace(/\..+/, '');
+
+        // textract -> vector db
+        const text = await DocumentParser.extractTextFromFile(key);
+        const embeddingsId = await this.ragService.insertDocument(
+            user,
+            text,
+            file.originalname
+        );
+
+        // mongodb
+        await Document.findOneAndUpdate(
+            { s3Path: key },
+            {
+                name: file.originalname,
+                email,
+                s3Path: key,
+                uploadDate: dateFormatted,
+                embeddingsId: embeddingsId,
+            },
+            { upsert: true, new: true }
+        );
+
+        return {
+            name: file.originalname,
+            uploadTime: dateFormatted
+        } as DocumentDTO;
+    }
+
+    /**
+     * Uploads multiple files to s3 and mongodb
+     *
+     */
+    public async uploadDocuments(
+        files: Express.Multer.File[],
+        email: string
+    ): Promise<DocumentDTO[]> {
+        const user = email.replace('@gmail.com', '');
+        await this.ragService.ensureVectorStore(user);
+
+        const docs = await Promise.all(
+            files.map((file) => this.uploadDocument(file, email, user))
+        );
+        return docs as DocumentDTO[];
+    }
+
+    /**
+     * Deletes a document on s3 and mongodb
+     *
+     */
+    public async deleteDocument(key: string): Promise<void> {
+        const params = {
+            Bucket: this.bucketName,
+            Key: key,
+        };
+
+        // s3
+        const command = new DeleteObjectCommand(params);
+        await this.s3Client.send(command);
+
+        // mongodb
+        await Document.deleteOne({ s3Path: key });
+        return;
+    }
+
+    /**
+     * Deletes documents on s3 and mongodb
+     *
+     */
+
+    public async deleteDocuments(
+        paths: string[],
+        email: string
+    ): Promise<void> {
+        const user = email.replace('@gmail.com', '');
+
+        await Promise.all(
+            paths.map((path) => this.deleteDocument(`${email}-${path}`))
+        );
+        await this.ragService.deleteDocuments(paths, user);
+        return;
+    }
+
+    /**
+     * Retrieves a document from s3
+     *
+     */
+    public async getDocument(
+        key: string,
+        email: string,
+        expiresIn: number = 3600
+    ): Promise<DocumentDTO> {
+
+        let params = {
+            Bucket: this.bucketName,
+            Key: `${email}-${key}`,
+        };
+
+        const command = new GetObjectCommand(params);
+        const documentUrl = await getSignedUrl(this.s3Client, command, {
+            expiresIn,
+        });
+        const doc = await Document.findOne({ s3Path: `${email}-${key}`})
+          
+        return {
+            url: documentUrl,
+            name: key,
+            uploadTime: doc!.uploadDate 
+        } as DocumentDTO;
+    }
+
+    /**
+     * Retrieves multiple documents from s3
+     *
+     */
+    public async getDocuments(keys: string[], email: string): Promise<DocumentDTO[]> {
+        let documents;
+        if (keys) {
+            documents = await Promise.all(
+                keys.map((key) => this.getDocument(key, email))
+            );
+        } else {
+            const allKeys = (await Document.find({ email: email })).map(
+                (doc) => doc.name
+            );
+            documents = await Promise.all(
+                allKeys.map((key) => this.getDocument(key, email))
+            );
+        }
+        return documents;
+    }
+}
+
+export default new DocumentService();


### PR DESCRIPTION
- Added document upload, delete, get endpoints
- On document upload, we now upload to S3, mongoDB and to a chromaDB collection and document deletion deletes from all 3 as well. I'm currently using email as a way to identify users' own documents so its easy to test without having to get an access token each time, but probably should protect routes and authenticate users based on jwt claims later on.
- Extra info: Embedding id of a document is the document name/path itself, the S3 path of a document is `{email}-{file_path}` so we can just store all user docs in a single bucket and differentiate docs between different users.

Check README.md for API docs