### PR TITLE
feat: implemented the chat screen + some chores

### DIFF
--- a/frontend/app/src/main/java/com/example/thinkr/app/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/app/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.navigation.navigation
 import com.example.thinkr.domain.DocumentManager
 import com.example.thinkr.domain.FlashcardsManager
 import com.example.thinkr.domain.model.DocumentItem
+import com.example.thinkr.ui.chat.ChatScreen
 import com.example.thinkr.ui.document_details.DocumentDetailsScreen
 import com.example.thinkr.ui.document_options.DocumentOptionsScreen
 import com.example.thinkr.ui.flashcards.FlashcardsScreen
@@ -162,6 +163,20 @@ class MainActivity : ComponentActivity() {
                                 val document =
                                     Json.decodeFromString<DocumentItem>(Uri.decode(json)) // Decode JSON back to object
                                 QuizScreen(document, navController)
+                            }
+
+                            composable(
+                                route = Route.Chat.ROUTE,
+                                arguments = listOf(navArgument(Route.Chat.ARGUMENT) {
+                                    type = NavType.StringType
+                                })
+                            ) { backStackEntry ->
+                                val json =
+                                    backStackEntry.arguments?.getString(Route.Chat.ARGUMENT)
+                                        ?: ""
+                                val document =
+                                    Json.decodeFromString<DocumentItem>(Uri.decode(json)) // Decode JSON back to object
+                                ChatScreen(document, navController)
                             }
                         }
                     }

--- a/frontend/app/src/main/java/com/example/thinkr/app/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/app/MainActivity.kt
@@ -20,7 +20,7 @@ import com.example.thinkr.domain.DocumentManager
 import com.example.thinkr.domain.FlashcardsManager
 import com.example.thinkr.domain.model.DocumentItem
 import com.example.thinkr.ui.chat.ChatScreen
-import com.example.thinkr.ui.document_details.DocumentDetailsScreen
+import com.example.thinkr.ui.document_upload.DocumentUploadScreen
 import com.example.thinkr.ui.document_options.DocumentOptionsScreen
 import com.example.thinkr.ui.flashcards.FlashcardsScreen
 import com.example.thinkr.ui.home.HomeScreen
@@ -106,16 +106,16 @@ class MainActivity : ComponentActivity() {
                             }
 
                             composable(
-                                route = Route.DocumentDetails.ROUTE,
-                                arguments = listOf(navArgument(Route.DocumentDetails.ARGUMENT) {
+                                route = Route.DocumentUpload.ROUTE,
+                                arguments = listOf(navArgument(Route.DocumentUpload.ARGUMENT) {
                                     type = NavType.StringType
                                 })
                             ) { backStackEntry ->
                                 val json =
-                                    backStackEntry.arguments?.getString(Route.DocumentDetails.ARGUMENT)
+                                    backStackEntry.arguments?.getString(Route.DocumentUpload.ARGUMENT)
                                         ?: ""
                                 val selectedUri = Uri.parse(Uri.decode(json))
-                                DocumentDetailsScreen(navController, selectedUri, documentManager)
+                                DocumentUploadScreen(navController, selectedUri, documentManager)
                             }
 
                             composable<Route.Profile> {

--- a/frontend/app/src/main/java/com/example/thinkr/app/Route.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/app/Route.kt
@@ -68,4 +68,16 @@ sealed interface Route {
             }
         }
     }
+
+    @Serializable
+    data class Chat(val documentItem: DocumentItem) : Route {
+        companion object {
+            const val ROUTE = "chat/{documentJson}"
+            const val ARGUMENT = "documentJson"
+            fun createRoute(document: DocumentItem): String {
+                val json = Json.encodeToString(document)
+                return ROUTE.replace("{documentJson}", Uri.encode(json))
+            }
+        }
+    }
 }

--- a/frontend/app/src/main/java/com/example/thinkr/app/Route.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/app/Route.kt
@@ -29,9 +29,9 @@ sealed interface Route {
     }
 
     @Serializable
-    data class DocumentDetails(val selectedUri: String) : Route {
+    data class DocumentUpload(val selectedUri: String) : Route {
         companion object {
-            const val ROUTE = "documentDetails/{selectedUri}"
+            const val ROUTE = "documentUpload/{selectedUri}"
             const val ARGUMENT = "selectedUri"
             fun createRoute(selectedUri: Uri): String {
                 return ROUTE.replace("{selectedUri}", Uri.encode(selectedUri.toString()))

--- a/frontend/app/src/main/java/com/example/thinkr/di/Modules.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/di/Modules.kt
@@ -10,6 +10,7 @@ import com.example.thinkr.ui.landing.LandingScreenViewModel
 import com.example.thinkr.ui.payment.PaymentViewModel
 import com.example.thinkr.ui.profile.ProfileViewModel
 import com.example.thinkr.ui.quiz.QuizViewModel
+import com.example.thinkr.ui.chat.ChatViewModel
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import org.koin.core.module.dsl.singleOf
@@ -27,4 +28,5 @@ val appModule = module {
     viewModelOf(::ProfileViewModel)
     viewModelOf(::PaymentViewModel)
     viewModelOf(::QuizViewModel)
+    viewModelOf(::ChatViewModel)
 }

--- a/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatScreen.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatScreen.kt
@@ -1,0 +1,189 @@
+package com.example.thinkr.ui.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.thinkr.domain.model.DocumentItem
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen(
+    document: DocumentItem,
+    navController: NavController,
+    viewModel: ChatViewModel = viewModel()
+) {
+    val chatState = viewModel.state.collectAsState().value
+    val messageText = remember { mutableStateOf("") }
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+
+    // Scroll to bottom when new message is added
+    LaunchedEffect(chatState.messages.size) {
+        if (chatState.messages.isNotEmpty()) {
+            listState.animateScrollToItem(chatState.messages.size - 1)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        TopAppBar(
+            title = { Text("Chat") },
+            navigationIcon = {
+                IconButton(
+                    onClick = { navController.popBackStack() }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        )
+
+        // Messages List
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                state = listState,
+                contentPadding = PaddingValues(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(chatState.messages) { message ->
+                    ChatMessageItem(message)
+                }
+            }
+        }
+
+        // Input Field
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()  // Adjusts for the navigation bar
+        ){
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = messageText.value,
+                    onValueChange = { messageText.value = it },
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 8.dp),
+                    placeholder = { Text("Type a message") },
+                    shape = RoundedCornerShape(24.dp),
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                    )
+                )
+
+                IconButton(
+                    onClick = {
+                        if (messageText.value.isNotBlank()) {
+                            viewModel.onSendMessage(messageText.value)
+                            messageText.value = ""
+                            coroutineScope.launch {
+                                if (chatState.messages.isNotEmpty()) {
+                                    listState.animateScrollToItem(chatState.messages.size)
+                                }
+                            }
+                        }
+                    },
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary)
+                        .padding(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = "Send Message",
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ChatMessageItem(message: Message) {
+    val isSender = message.isSender
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalAlignment = if (isSender) Alignment.End else Alignment.Start
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 280.dp)
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp,
+                        topEnd = 16.dp,
+                        bottomStart = if (isSender) 16.dp else 4.dp,
+                        bottomEnd = if (isSender) 4.dp else 16.dp
+                    )
+                )
+                .background(
+                    if (isSender) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.secondaryContainer
+                )
+                .padding(12.dp)
+        ) {
+            Text(
+                text = message.content.value,
+                style = TextStyle(
+                    color = if (isSender) MaterialTheme.colorScheme.onPrimary
+                    else MaterialTheme.colorScheme.onSecondaryContainer,
+                    fontSize = 16.sp
+                )
+            )
+
+            // Timestamp
+            Text(
+                text = message.formattedTime,
+                style = TextStyle(
+                    color = if (isSender) MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f)
+                    else MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Light
+                ),
+                modifier = Modifier.align(Alignment.End)
+            )
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatState.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatState.kt
@@ -1,0 +1,24 @@
+package com.example.thinkr.ui.chat
+
+import androidx.compose.runtime.State
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+data class ChatState(
+    val messages: List<Message> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+data class Message(
+    val id: String,
+    val content: State<String>,
+    val timestamp: Long,
+    val isSender: Boolean
+)
+val Message.formattedTime: String
+    get() {
+        val sdf = SimpleDateFormat("h:mm a", Locale.getDefault())
+        return sdf.format(Date(timestamp))
+    }

--- a/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatViewModel.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/chat/ChatViewModel.kt
@@ -1,0 +1,98 @@
+package com.example.thinkr.ui.chat
+
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ChatViewModel : ViewModel() {
+    private val _state = MutableStateFlow(ChatState())
+    val state: StateFlow<ChatState> = _state.asStateFlow()
+
+    init {
+        // TODO: Remove this and replace it with the messages received from the backend
+        _state.update { currentState ->
+            currentState.copy(
+                messages = listOf(
+                    Message(
+                        id = "1",
+                        content = mutableStateOf("Hello there!"),
+                        timestamp = System.currentTimeMillis() - 3600000,
+                        isSender = false
+                    ),
+                    Message(
+                        id = "2",
+                        content = mutableStateOf("Hi! How are you?"),
+                        timestamp = System.currentTimeMillis() - 3500000,
+                        isSender = true
+                    ),
+                    Message(
+                        id = "3",
+                        content = mutableStateOf("I'm doing great, thanks for asking. How about you?"),
+                        timestamp = System.currentTimeMillis() - 3400000,
+                        isSender = false
+                    )
+                )
+            )
+        }
+    }
+
+    fun onSendMessage(content: String) {
+        if (content.isBlank()) return
+
+        val newMessage = Message(
+            id = System.currentTimeMillis().toString(),
+            content = mutableStateOf(content),
+            timestamp = System.currentTimeMillis(),
+            isSender = true
+        )
+
+        _state.update { currentState ->
+            currentState.copy(
+                messages = currentState.messages + newMessage
+            )
+        }
+
+
+        // TODO: Remove this, just for demonstration purposes
+        viewModelScope.launch {
+            kotlinx.coroutines.delay(1000)
+            onReceiveMessage( "I received your message: \"$content\"")
+        }
+    }
+
+    fun onReceiveMessage(content: String) {
+        val contentStream = mutableStateOf("")
+        if (content.isBlank()) return
+
+        val newMessage = Message(
+            id = System.currentTimeMillis().toString(),
+            content = contentStream,
+            timestamp = System.currentTimeMillis(),
+            isSender = false
+        )
+
+        _state.update { currentState ->
+            currentState.copy(
+                messages = currentState.messages + newMessage
+            )
+        }
+
+        // Gives a "streaming" effect to the message
+        viewModelScope.launch {
+            content.forEach { char ->
+                contentStream.value += char
+                kotlinx.coroutines.delay(MESSAGE_STREAM_DELAY)
+            }
+        }
+    }
+
+    companion object {
+        private const val MESSAGE_STREAM_DELAY = 50L
+    }
+}

--- a/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadScreen.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadScreen.kt
@@ -1,4 +1,4 @@
-package com.example.thinkr.ui.document_details
+package com.example.thinkr.ui.document_upload
 
 import android.net.Uri
 import android.widget.Toast
@@ -37,11 +37,11 @@ import com.example.thinkr.R
 import com.example.thinkr.domain.DocumentManager
 
 @Composable
-fun DocumentDetailsScreen(
+fun DocumentUploadScreen(
     navController: NavController,
     selectedUri: Uri,
     documentManager: DocumentManager,
-    viewModel: DocumentDetailsViewModel = DocumentDetailsViewModel(documentManager = documentManager)
+    viewModel: DocumentUploadViewModel = DocumentUploadViewModel(documentManager = documentManager)
 ) {
     var name by remember { mutableStateOf("") }
     var context by remember { mutableStateOf("") }

--- a/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadScreen.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadScreen.kt
@@ -4,10 +4,8 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,9 +14,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +40,7 @@ import androidx.navigation.NavController
 import com.example.thinkr.R
 import com.example.thinkr.domain.DocumentManager
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DocumentUploadScreen(
     navController: NavController,
@@ -47,21 +52,26 @@ fun DocumentUploadScreen(
     var context by remember { mutableStateOf("") }
     val contextForToast = LocalContext.current
 
-    Row {
-        Image(
-            painter = painterResource(id = R.drawable.arrow_back),
-            contentDescription = "Back",
-            modifier = Modifier
-                .size(48.dp)
-                .clickable { viewModel.onBackPressed(navController) }
-        )
-    }
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        TopAppBar(
+            title = { Text("Upload Document") },
+            navigationIcon = {
+                IconButton(
+                    onClick = { viewModel.onBackPressed(navController) }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        )
+
         Spacer(modifier = Modifier.height(80.dp))
 
         Box(

--- a/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadState.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadState.kt
@@ -1,8 +1,8 @@
-package com.example.thinkr.ui.document_details
+package com.example.thinkr.ui.document_upload
 
 import android.net.Uri
 
-data class DocumentDetailsState(
+data class DocumentUploadState(
     val name: String = "document name",
     val context: String = "context",
     val uri: Uri = Uri.EMPTY

--- a/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadViewModel.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/document_upload/DocumentUploadViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.thinkr.ui.document_details
+package com.example.thinkr.ui.document_upload
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
@@ -8,8 +8,8 @@ import com.example.thinkr.domain.DocumentManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
-class DocumentDetailsViewModel(private val documentManager: DocumentManager) : ViewModel() {
-    private val _state = MutableStateFlow(DocumentDetailsState())
+class DocumentUploadViewModel(private val documentManager: DocumentManager) : ViewModel() {
+    private val _state = MutableStateFlow(DocumentUploadState())
 
     fun onBackPressed(navController: NavController) {
         navController.navigate(Route.Home)

--- a/frontend/app/src/main/java/com/example/thinkr/ui/flashcards/FlashcardsScreen.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/flashcards/FlashcardsScreen.kt
@@ -1,29 +1,26 @@
 package com.example.thinkr.ui.flashcards
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import com.example.thinkr.R
 import com.example.thinkr.domain.FlashcardsManager
 import com.example.thinkr.domain.model.DocumentItem
 import androidx.compose.material3.*
 import com.example.thinkr.ui.shared.AnimatedCardDeck
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FlashcardsScreen(documentItem: DocumentItem, navController: NavController, flashcardsManager: FlashcardsManager, viewModel: FlashcardsViewModel = FlashcardsViewModel(flashcardsManager)) {
     val flashcards = flashcardsManager.getFlashcards(documentItem)
@@ -58,15 +55,19 @@ fun FlashcardsScreen(documentItem: DocumentItem, navController: NavController, f
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-        Row {
-            Image(
-                painter = painterResource(id = R.drawable.arrow_back),
-                contentDescription = "Back",
-                modifier = Modifier
-                    .size(48.dp)
-                    .clickable { viewModel.onBackPressed(navController) }
-            )
-        }
+        TopAppBar(
+            title = { Text("Flashcards") },
+            navigationIcon = {
+                IconButton(
+                    onClick = { viewModel.onBackPressed(navController) }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        )
 
         Box(
             modifier = Modifier

--- a/frontend/app/src/main/java/com/example/thinkr/ui/home/HomeScreenViewModel.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/home/HomeScreenViewModel.kt
@@ -40,7 +40,7 @@ class HomeScreenViewModel(documentManager: DocumentManager) : ViewModel() {
             }
             is HomeScreenAction.FileSelected -> {
                 // Handle file selected action
-                navController.navigate(Route.DocumentDetails.createRoute(action.selectedUri))
+                navController.navigate(Route.DocumentUpload.createRoute(action.selectedUri))
             }
         }
     }

--- a/frontend/app/src/main/java/com/example/thinkr/ui/quiz/QuizScreen.kt
+++ b/frontend/app/src/main/java/com/example/thinkr/ui/quiz/QuizScreen.kt
@@ -7,9 +7,7 @@ import android.os.VibratorManager
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,13 +18,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,13 +44,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import com.example.thinkr.R
 import com.example.thinkr.domain.model.DocumentItem
 import com.example.thinkr.ui.shared.AnimatedCardDeck
 import kotlinx.coroutines.delay
@@ -59,6 +60,7 @@ data class Quiz(
     var correctAnswerIndexList: List<Int> = emptyList()
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QuizScreen(
     document: DocumentItem,
@@ -107,15 +109,19 @@ fun QuizScreen(
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            Row {
-                Image(
-                    painter = painterResource(id = R.drawable.arrow_back),
-                    contentDescription = "Back",
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clickable { viewModel.onBackPressed(navController) }
-                )
-            }
+            TopAppBar(
+                title = { Text("Quiz") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { viewModel.onBackPressed(navController) }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
 
             Box(
                 modifier = Modifier
@@ -131,15 +137,19 @@ fun QuizScreen(
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            Row {
-                Image(
-                    painter = painterResource(id = R.drawable.arrow_back),
-                    contentDescription = "Back",
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clickable { viewModel.onBackPressed(navController) }
-                )
-            }
+            TopAppBar(
+                title = { Text("Quiz") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { viewModel.onBackPressed(navController) }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
* Implemented the `ChatScreen`
  * Added a streaming effect to the receiving messages to give `chatgpt` vibes
* Renamed the `document_details` to `document_upload` as previously discussed with @jaidensiu 
* Modified the top bar navigation to use `TopAppBar`